### PR TITLE
Updated Rust Api: Address & Tx; removed unused imports 

### DIFF
--- a/example/lib/test_app.dart
+++ b/example/lib/test_app.dart
@@ -1,6 +1,4 @@
-import 'dart:ffi';
 import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:lwk_dart/lwk_dart.dart';
 import 'package:path_provider/path_provider.dart';
@@ -32,7 +30,7 @@ class TestApp extends StatefulWidget {
       return path;
     } catch (e) {
       print('Error getting current directory: $e');
-      throw (e);
+      rethrow;
     }
   }
 
@@ -117,26 +115,26 @@ class _TestAppState extends State<TestApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        scrollbarTheme: ScrollbarThemeData(
+        scrollbarTheme: const ScrollbarThemeData(
           minThumbLength: 10,
           thumbVisibility: MaterialStatePropertyAll<bool>(true),
           thumbColor: MaterialStatePropertyAll<Color>(Colors.grey),
         ),
-        textTheme: TextTheme(
+        textTheme: const TextTheme(
           bodyMedium: TextStyle(fontSize: 18.0),
         ),
         textButtonTheme: TextButtonThemeData(
           style: ButtonStyle(
             backgroundColor:
                 MaterialStatePropertyAll<Color>(Colors.red.shade400),
-            foregroundColor: MaterialStatePropertyAll<Color>(Colors.white),
+            foregroundColor: const MaterialStatePropertyAll<Color>(Colors.white),
           ),
         ),
       ),
       home: Scaffold(
         appBar: AppBar(
           backgroundColor: Colors.red.shade400,
-          title: Text("LWK Flutter Lib Test:"),
+          title: const Text("LWK Flutter Lib Test:"),
         ),
         body: Center(
           child: Padding(
@@ -147,9 +145,9 @@ class _TestAppState extends State<TestApp> {
                   children: [
                     Visibility(
                       visible: loading,
-                      child: LinearProgressIndicator(),
+                      child: const LinearProgressIndicator(),
                     ),
-                    SizedBox(
+                    const SizedBox(
                       height: 50,
                     ),
                     Column(
@@ -235,7 +233,7 @@ class _TestAppState extends State<TestApp> {
                               ),
                             ),
                             txs == null
-                                ? Text("...")
+                                ? const Text("...")
                                 : Container(
                                     decoration: BoxDecoration(
                                       border: Border.all(
@@ -297,7 +295,7 @@ class _TestAppState extends State<TestApp> {
                               ),
                             ),
                             pset == null
-                                ? Text("...")
+                                ? const Text("...")
                                 : Container(
                                     height: 300,
                                     decoration: BoxDecoration(
@@ -330,7 +328,7 @@ class _TestAppState extends State<TestApp> {
                               ),
                             ),
                             decodedPset == null
-                                ? Text("...")
+                                ? const Text("...")
                                 : Text(
                                     'Amount: ${decodedPset!.amount}, Fee: ${decodedPset!.fee}'),
                           ],

--- a/ios/Classes/bindings.h
+++ b/ios/Classes/bindings.h
@@ -37,7 +37,12 @@ void wire_sync__static_method__Api(int64_t port_,
 
 void wire_descriptor__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
 
-void wire_address__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
+void wire_address_last_unused__static_method__Api(int64_t port_,
+                                                  struct wire_uint_8_list *wallet_id);
+
+void wire_address__static_method__Api(int64_t port_,
+                                      struct wire_uint_8_list *wallet_id,
+                                      uint32_t index);
 
 void wire_balance__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
 
@@ -72,6 +77,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_new_wallet__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_sync__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_descriptor__static_method__Api);
+    dummy_var ^= ((int64_t) (void*) wire_address_last_unused__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_address__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_balance__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_txs__static_method__Api);

--- a/lib/src/generated/bindings.dart
+++ b/lib/src/generated/bindings.dart
@@ -92,16 +92,38 @@ class LwkBridgeImpl implements LwkBridge {
         argNames: ["walletId"],
       );
 
-  Future<String> addressStaticMethodApi(
+  Future<WalletAddress> addressLastUnusedStaticMethodApi(
       {required String walletId, dynamic hint}) {
     var arg0 = _platform.api2wire_String(walletId);
     return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner
+          .wire_address_last_unused__static_method__Api(port_, arg0),
+      parseSuccessData: _wire2api_wallet_address,
+      parseErrorData: _wire2api_lwk_error,
+      constMeta: kAddressLastUnusedStaticMethodApiConstMeta,
+      argValues: [walletId],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta
+      get kAddressLastUnusedStaticMethodApiConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "address_last_unused__static_method__Api",
+            argNames: ["walletId"],
+          );
+
+  Future<WalletAddress> addressStaticMethodApi(
+      {required String walletId, required int index, dynamic hint}) {
+    var arg0 = _platform.api2wire_String(walletId);
+    var arg1 = api2wire_u32(index);
+    return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) =>
-          _platform.inner.wire_address__static_method__Api(port_, arg0),
-      parseSuccessData: _wire2api_String,
+          _platform.inner.wire_address__static_method__Api(port_, arg0, arg1),
+      parseSuccessData: _wire2api_wallet_address,
       parseErrorData: _wire2api_lwk_error,
       constMeta: kAddressStaticMethodApiConstMeta,
-      argValues: [walletId],
+      argValues: [walletId, index],
       hint: hint,
     ));
   }
@@ -109,7 +131,7 @@ class LwkBridgeImpl implements LwkBridge {
   FlutterRustBridgeTaskConstMeta get kAddressStaticMethodApiConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
         debugName: "address__static_method__Api",
-        argNames: ["walletId"],
+        argNames: ["walletId", "index"],
       );
 
   Future<Balance> balanceStaticMethodApi(
@@ -274,6 +296,10 @@ class LwkBridgeImpl implements LwkBridge {
     return (raw as List<dynamic>).map(_wire2api_tx).toList();
   }
 
+  List<TxOut> _wire2api_list_tx_out(dynamic raw) {
+    return (raw as List<dynamic>).map(_wire2api_tx_out).toList();
+  }
+
   LwkError _wire2api_lwk_error(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 1)
@@ -301,9 +327,23 @@ class LwkBridgeImpl implements LwkBridge {
       kind: _wire2api_String(arr[0]),
       amount: _wire2api_u64(arr[1]),
       txid: _wire2api_String(arr[2]),
-      address: _wire2api_String(arr[3]),
+      outputs: _wire2api_list_tx_out(arr[3]),
       fee: _wire2api_u64(arr[4]),
     );
+  }
+
+  TxOut _wire2api_tx_out(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return TxOut(
+      address: _wire2api_String(arr[0]),
+      amount: _wire2api_u64(arr[1]),
+    );
+  }
+
+  int _wire2api_u32(dynamic raw) {
+    return raw as int;
   }
 
   int _wire2api_u64(dynamic raw) {
@@ -320,6 +360,17 @@ class LwkBridgeImpl implements LwkBridge {
 
   void _wire2api_unit(dynamic raw) {
     return;
+  }
+
+  WalletAddress _wire2api_wallet_address(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return WalletAddress(
+      standard: _wire2api_String(arr[0]),
+      confidential: _wire2api_String(arr[1]),
+      index: _wire2api_u32(arr[2]),
+    );
   }
 }
 
@@ -338,6 +389,11 @@ int api2wire_i32(int raw) {
 @protected
 int api2wire_liquid_network(LiquidNetwork raw) {
   return api2wire_i32(raw.index);
+}
+
+@protected
+int api2wire_u32(int raw) {
+  return raw;
 }
 
 @protected
@@ -532,23 +588,43 @@ class LwkBridgeWire implements FlutterRustBridgeWireBase {
       _wire_descriptor__static_method__ApiPtr
           .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  void wire_address__static_method__Api(
+  void wire_address_last_unused__static_method__Api(
     int port_,
     ffi.Pointer<wire_uint_8_list> wallet_id,
   ) {
-    return _wire_address__static_method__Api(
+    return _wire_address_last_unused__static_method__Api(
       port_,
       wallet_id,
     );
   }
 
-  late final _wire_address__static_method__ApiPtr = _lookup<
+  late final _wire_address_last_unused__static_method__ApiPtr = _lookup<
           ffi.NativeFunction<
               ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_address__static_method__Api');
+      'wire_address_last_unused__static_method__Api');
+  late final _wire_address_last_unused__static_method__Api =
+      _wire_address_last_unused__static_method__ApiPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_address__static_method__Api(
+    int port_,
+    ffi.Pointer<wire_uint_8_list> wallet_id,
+    int index,
+  ) {
+    return _wire_address__static_method__Api(
+      port_,
+      wallet_id,
+      index,
+    );
+  }
+
+  late final _wire_address__static_method__ApiPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Uint32)>>('wire_address__static_method__Api');
   late final _wire_address__static_method__Api =
       _wire_address__static_method__ApiPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   void wire_balance__static_method__Api(
     int port_,

--- a/lib/src/generated/bridge_definitions.dart
+++ b/lib/src/generated/bridge_definitions.dart
@@ -27,8 +27,13 @@ abstract class LwkBridge {
 
   FlutterRustBridgeTaskConstMeta get kDescriptorStaticMethodApiConstMeta;
 
-  Future<String> addressStaticMethodApi(
+  Future<WalletAddress> addressLastUnusedStaticMethodApi(
       {required String walletId, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAddressLastUnusedStaticMethodApiConstMeta;
+
+  Future<WalletAddress> addressStaticMethodApi(
+      {required String walletId, required int index, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kAddressStaticMethodApiConstMeta;
 
@@ -106,14 +111,36 @@ class Tx {
   final String kind;
   final int amount;
   final String txid;
-  final String address;
+  final List<TxOut> outputs;
   final int fee;
 
   const Tx({
     required this.kind,
     required this.amount,
     required this.txid,
-    required this.address,
+    required this.outputs,
     required this.fee,
+  });
+}
+
+class TxOut {
+  final String address;
+  final int amount;
+
+  const TxOut({
+    required this.address,
+    required this.amount,
+  });
+}
+
+class WalletAddress {
+  final String standard;
+  final String confidential;
+  final int index;
+
+  const WalletAddress({
+    required this.standard,
+    required this.confidential,
+    required this.index,
   });
 }

--- a/lib/src/root.dart
+++ b/lib/src/root.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:lwk_dart/src/utils/loader.dart';
-import 'generated/bridge_definitions.dart' as bridge;
 import 'generated/bridge_definitions.dart';
 
 Future<void> setCurrentDirectory() async {
@@ -47,9 +46,9 @@ class LiquidWallet {
     }
   }
 
-  Future<String> address() async {
+  Future<WalletAddress> address() async {
     try {
-      final res = await ffi.addressStaticMethodApi(
+      final res = await ffi.addressLastUnusedStaticMethodApi(
         walletId: _liquidWallet,
       );
       return res;

--- a/macos/Classes/bindings.h
+++ b/macos/Classes/bindings.h
@@ -37,7 +37,12 @@ void wire_sync__static_method__Api(int64_t port_,
 
 void wire_descriptor__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
 
-void wire_address__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
+void wire_address_last_unused__static_method__Api(int64_t port_,
+                                                  struct wire_uint_8_list *wallet_id);
+
+void wire_address__static_method__Api(int64_t port_,
+                                      struct wire_uint_8_list *wallet_id,
+                                      uint32_t index);
 
 void wire_balance__static_method__Api(int64_t port_, struct wire_uint_8_list *wallet_id);
 
@@ -72,6 +77,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_new_wallet__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_sync__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_descriptor__static_method__Api);
+    dummy_var ^= ((int64_t) (void*) wire_address_last_unused__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_address__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_balance__static_method__Api);
     dummy_var ^= ((int64_t) (void*) wire_txs__static_method__Api);

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -826,7 +826,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi 0.3.5",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1036,7 +1036,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi 0.3.5",
  "libc",
 ]
 
@@ -1465,13 +1465,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -29,8 +29,20 @@ pub extern "C" fn wire_descriptor__static_method__Api(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_address__static_method__Api(port_: i64, wallet_id: *mut wire_uint_8_list) {
-    wire_address__static_method__Api_impl(port_, wallet_id)
+pub extern "C" fn wire_address_last_unused__static_method__Api(
+    port_: i64,
+    wallet_id: *mut wire_uint_8_list,
+) {
+    wire_address_last_unused__static_method__Api_impl(port_, wallet_id)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_address__static_method__Api(
+    port_: i64,
+    wallet_id: *mut wire_uint_8_list,
+    index: u32,
+) {
+    wire_address__static_method__Api_impl(port_, wallet_id, index)
 }
 
 #[no_mangle]

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -25,6 +25,8 @@ use crate::network::LiquidNetwork;
 use crate::types::Balance;
 use crate::types::PsetAmounts;
 use crate::types::Tx;
+use crate::types::TxOut;
+use crate::types::WalletAddress;
 
 // Section: wire functions
 
@@ -82,11 +84,28 @@ fn wire_descriptor__static_method__Api_impl(
         },
     )
 }
-fn wire_address__static_method__Api_impl(
+fn wire_address_last_unused__static_method__Api_impl(
     port_: MessagePort,
     wallet_id: impl Wire2Api<String> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, WalletAddress, _>(
+        WrapInfo {
+            debug_name: "address_last_unused__static_method__Api",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_wallet_id = wallet_id.wire2api();
+            move |task_callback| Api::address_last_unused(api_wallet_id)
+        },
+    )
+}
+fn wire_address__static_method__Api_impl(
+    port_: MessagePort,
+    wallet_id: impl Wire2Api<String> + UnwindSafe,
+    index: impl Wire2Api<u32> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, WalletAddress, _>(
         WrapInfo {
             debug_name: "address__static_method__Api",
             port: Some(port_),
@@ -94,7 +113,8 @@ fn wire_address__static_method__Api_impl(
         },
         move || {
             let api_wallet_id = wallet_id.wire2api();
-            move |task_callback| Api::address(api_wallet_id)
+            let api_index = index.wire2api();
+            move |task_callback| Api::address(api_wallet_id, api_index)
         },
     )
 }
@@ -254,6 +274,11 @@ impl Wire2Api<LiquidNetwork> for i32 {
         }
     }
 }
+impl Wire2Api<u32> for u32 {
+    fn wire2api(self) -> u32 {
+        self
+    }
+}
 impl Wire2Api<u64> for u64 {
     fn wire2api(self) -> u64 {
         self
@@ -313,7 +338,7 @@ impl support::IntoDart for Tx {
             self.kind.into_into_dart().into_dart(),
             self.amount.into_into_dart().into_dart(),
             self.txid.into_into_dart().into_dart(),
-            self.address.into_into_dart().into_dart(),
+            self.outputs.into_into_dart().into_dart(),
             self.fee.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -321,6 +346,39 @@ impl support::IntoDart for Tx {
 }
 impl support::IntoDartExceptPrimitive for Tx {}
 impl rust2dart::IntoIntoDart<Tx> for Tx {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for TxOut {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.address.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for TxOut {}
+impl rust2dart::IntoIntoDart<TxOut> for TxOut {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for WalletAddress {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.standard.into_into_dart().into_dart(),
+            self.confidential.into_into_dart().into_dart(),
+            self.index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for WalletAddress {}
+impl rust2dart::IntoIntoDart<WalletAddress> for WalletAddress {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/test/lwk_static_test.dart
+++ b/test/lwk_static_test.dart
@@ -18,7 +18,7 @@ void main() {
       print('$walletId');
 
       await ffi.syncStaticMethodApi(electrumUrl: electrumUrl, walletId: walletId);
-      final address = await ffi.addressStaticMethodApi(walletId: walletId);
+      final address = await ffi.addressLastUnusedStaticMethodApi(walletId: walletId);
       print('$address');
 
       final balance = await ffi.balanceStaticMethodApi(walletId: walletId);
@@ -29,7 +29,7 @@ void main() {
         print('${element.kind}');
         print('${element.amount}');
         print('${element.txid}');
-        print('${element.address}');
+        print('${element.outputs}');
         print('---------------------------');
       });
       const outAddress =


### PR DESCRIPTION
Rust Api updates:
address now returns WalletAddress (confidential &  unconfidential) instead of string
txs now returns address along with amount & fee

Removed unused imports