### PR TITLE
Add error to exports

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/codegen.sh
+++ b/codegen.sh
@@ -3,4 +3,4 @@
 cd rust
 cargo update
 cd - || exit 1
-flutter_rust_bridge_codegen generate
+flutter_rust_bridge_codegen ./flutter_rust_bridge_codegen

--- a/codegen.sh
+++ b/codegen.sh
@@ -3,4 +3,4 @@
 cd rust
 cargo update
 cd - || exit 1
-flutter_rust_bridge_codegen ./flutter_rust_bridge_codegen
+flutter_rust_bridge_codegen generate

--- a/compile.native.sh
+++ b/compile.native.sh
@@ -2,12 +2,12 @@
 mkdir -p build/unit_test_assets
 cd rust || exit 1
 cargo update
-cargo build --release
+cargo build --release --target=aarch64-apple-darwin
 OS=$(uname -s)
 if [ "$OS" = "Linux" ]; then
-    cp target/release/liblwkbridge.so ../build/unit_test_assets
+    cp target/aarch64-apple-darwin/release/liblwkbridge.so ../build/unit_test_assets
 elif [ "$OS" = "Darwin" ]; then
-    cp target/release/liblwkbridge.dylib ../build/unit_test_assets
+    cp target/aarch64-apple-darwin/release/liblwkbridge.dylib ../build/unit_test_assets
 else
     echo "Unsupported OS: $OS"
     exit 1

--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -156,6 +156,8 @@ void frbgen_lwk_dart_wire_wallet_sync(int64_t port_,
 
 void frbgen_lwk_dart_wire_wallet_txs(int64_t port_, struct wire_cst_wallet *that);
 
+void frbgen_lwk_dart_wire_wallet_utxos(int64_t port_, struct wire_cst_wallet *that);
+
 void frbgen_lwk_dart_rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(const void *ptr);
 
 void frbgen_lwk_dart_rust_arc_decrement_strong_count_RustOpaque_Mutexlwk_wolletWollet(const void *ptr);
@@ -203,6 +205,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_sign_tx);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_txs);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_utxos);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     return dummy_var;
 }

--- a/lib/lwk_dart.dart
+++ b/lib/lwk_dart.dart
@@ -2,6 +2,7 @@ library lwk_dart;
 
 export './src/generated/frb_generated.dart';
 export './src/generated/api/descriptor.dart';
+export './src/generated/api/error.dart';
 export './src/generated/api/wallet.dart';
 export './src/generated/api/types.dart';
 export './src/root.dart';

--- a/lib/src/generated/api/wallet.dart
+++ b/lib/src/generated/api/wallet.dart
@@ -113,6 +113,9 @@ class Wallet {
   Future<List<Tx>> txs({dynamic hint}) =>
       LwkCore.instance.api.walletTxs(that: this, hint: hint);
 
+  Future<List<TxOut>> utxos({dynamic hint}) =>
+      LwkCore.instance.api.walletUtxos(that: this, hint: hint);
+
   @override
   int get hashCode => ptr.hashCode;
 

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -126,6 +126,8 @@ abstract class LwkCoreApi extends BaseApi {
 
   Future<List<Tx>> walletTxs({required Wallet that, dynamic hint});
 
+  Future<List<TxOut>> walletUtxos({required Wallet that, dynamic hint});
+
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_MutexLwkWolletWollet;
 
@@ -559,6 +561,29 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
 
   TaskConstMeta get kWalletTxsConstMeta => const TaskConstMeta(
         debugName: "wallet_txs",
+        argNames: ["that"],
+      );
+
+  @override
+  Future<List<TxOut>> walletUtxos({required Wallet that, dynamic hint}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        var arg0 = cst_encode_box_autoadd_wallet(that);
+        return wire.wire_wallet_utxos(port_, arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_list_tx_out,
+        decodeErrorData: dco_decode_lwk_error,
+      ),
+      constMeta: kWalletUtxosConstMeta,
+      argValues: [that],
+      apiImpl: this,
+      hint: hint,
+    ));
+  }
+
+  TaskConstMeta get kWalletUtxosConstMeta => const TaskConstMeta(
+        debugName: "wallet_utxos",
         argNames: ["that"],
       );
 

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -914,6 +914,23 @@ class LwkCoreWire implements BaseWire {
   late final _wire_wallet_txs = _wire_wallet_txsPtr
       .asFunction<void Function(int, ffi.Pointer<wire_cst_wallet>)>();
 
+  void wire_wallet_utxos(
+    int port_,
+    ffi.Pointer<wire_cst_wallet> that,
+  ) {
+    return _wire_wallet_utxos(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire_wallet_utxosPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_cst_wallet>)>>(
+      'frbgen_lwk_dart_wire_wallet_utxos');
+  late final _wire_wallet_utxos = _wire_wallet_utxosPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_cst_wallet>)>();
+
   void rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(
     ffi.Pointer<ffi.Void> ptr,
   ) {

--- a/lib/src/generated/frb_generated.web.dart
+++ b/lib/src/generated/frb_generated.web.dart
@@ -552,6 +552,9 @@ class LwkCoreWire implements BaseWire {
   void wire_wallet_txs(NativePortType port_, List<dynamic> that) =>
       wasmModule.wire_wallet_txs(port_, that);
 
+  void wire_wallet_utxos(NativePortType port_, List<dynamic> that) =>
+      wasmModule.wire_wallet_utxos(port_, that);
+
   void rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(
           dynamic ptr) =>
       wasmModule
@@ -627,6 +630,8 @@ class LwkCoreWasmModule implements WasmModule {
       NativePortType port_, List<dynamic> that, String electrum_url);
 
   external void wire_wallet_txs(NativePortType port_, List<dynamic> that);
+
+  external void wire_wallet_utxos(NativePortType port_, List<dynamic> that);
 
   external void
       rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -156,6 +156,8 @@ void frbgen_lwk_dart_wire_wallet_sync(int64_t port_,
 
 void frbgen_lwk_dart_wire_wallet_txs(int64_t port_, struct wire_cst_wallet *that);
 
+void frbgen_lwk_dart_wire_wallet_utxos(int64_t port_, struct wire_cst_wallet *that);
+
 void frbgen_lwk_dart_rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(const void *ptr);
 
 void frbgen_lwk_dart_rust_arc_decrement_strong_count_RustOpaque_Mutexlwk_wolletWollet(const void *ptr);
@@ -203,6 +205,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_sign_tx);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_txs);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_dart_wire_wallet_utxos);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);
     return dummy_var;
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1771,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1810,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -108,47 +108,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -156,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 dependencies = [
  "backtrace",
 ]
@@ -182,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -377,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
@@ -441,7 +442,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -452,9 +453,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -561,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -575,7 +576,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -653,13 +654,13 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19cbb53d33b57ac4df1f0af6b92c38c107cded663c4aea9fae1189dcfc17cf5"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -671,7 +672,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -702,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fern"
@@ -725,7 +726,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -795,7 +796,7 @@ dependencies = [
  "serial_test",
  "strum",
  "strum_macros",
- "syn 2.0.60",
+ "syn 2.0.61",
  "tempfile",
  "toml 0.5.11",
  "topological-sort",
@@ -809,7 +810,7 @@ checksum = "e02edfe56f04af804d3145b17dfe7820d46a6753b214160f227dbdfa1073f7cb"
 dependencies = [
  "hex",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -877,7 +878,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -922,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -957,9 +958,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -1075,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1142,6 +1143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,9 +1200,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "linked-hash-map"
@@ -1211,9 +1218,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1338,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a000cf8bbbfb123a9bdc66b61c2885a4bb038df4f2629884caafabeb76b0f9"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
 dependencies = [
  "log",
  "once_cell",
@@ -1395,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1452,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1462,22 +1469,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -1523,9 +1530,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1579,6 +1586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
@@ -1643,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -1665,15 +1681,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1746,18 +1762,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -1783,13 +1799,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1846,7 +1862,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1914,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1937,22 +1953,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2058,7 +2074,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2099,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "universal-hash"
@@ -2168,7 +2184,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -2202,7 +2218,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2247,9 +2263,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -2410,9 +2426,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]

--- a/rust/api.rs
+++ b/rust/api.rs
@@ -104,6 +104,10 @@ impl Api {
         Wallet::retrieve_wallet(wallet_id)?.txs()
     }
 
+    pub fn utxos(wallet_id: String) -> anyhow::Result<Vec<Tx>, LwkError> {
+        Wallet::retrieve_wallet(wallet_id)?.utxos()
+    }
+
     pub fn build_lbtc_tx(
         wallet_id: String,
         sats: u64,

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -2,7 +2,7 @@ use elements::hex::{FromHex, ToHex};
 use elements::{secp256k1_zkp, AddressParams, AssetId, Script};
 use flutter_rust_bridge::frb;
 use lwk_common::PsetBalance;
-use lwk_wollet::{AddressResult, WalletTx};
+use lwk_wollet::{AddressResult, WalletTx, WalletTxOut};
 use std::collections::HashMap;
 use std::str::FromStr;
 use elements::Address as LwkAddress;
@@ -137,7 +137,25 @@ impl Address {
             })
         }
     }
+}
 
+impl From<WalletTxOut> for TxOut {
+    fn from(wallet_tx_out: WalletTxOut) -> Self {
+        TxOut {
+            script_pubkey: wallet_tx_out.script_pubkey.to_hex(),
+            height: wallet_tx_out.height,
+            unblinded: TxOutSecrets {
+                value: wallet_tx_out.unblinded.value,
+                value_bf: wallet_tx_out.unblinded.value_bf.to_string(),
+                asset: wallet_tx_out.unblinded.asset.to_string(),
+                asset_bf: wallet_tx_out.unblinded.asset_bf.to_string(),
+            },
+            outpoint: OutPoint {
+                txid: wallet_tx_out.outpoint.txid.to_string(),
+                vout: wallet_tx_out.outpoint.vout,
+            },
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -30,6 +30,7 @@ use super::types::Balances;
 use super::types::Network;
 use super::types::PsetAmounts;
 use super::types::Tx;
+use super::types::TxOut;
 
 pub struct Wallet {
     pub ptr: RustOpaque<Mutex<lwk_wollet::Wollet>>,
@@ -106,6 +107,12 @@ impl Wallet {
             .map(|x| Tx::from(x.to_owned()))
             .collect();
         Ok(txs)
+    }
+
+    pub fn utxos(&self) -> anyhow::Result<Vec<TxOut>, LwkError> {
+        let wallet_tx_outs = self.get_wallet().utxos()?;
+        let tx_outs = wallet_tx_outs.into_iter().map(TxOut::from).collect();
+        Ok(tx_outs)
     }
 
     pub fn build_lbtc_tx(

--- a/rust/src/frb_generated.io.rs
+++ b/rust/src/frb_generated.io.rs
@@ -465,6 +465,11 @@ pub extern "C" fn frbgen_lwk_dart_wire_wallet_txs(port_: i64, that: *mut wire_cs
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_lwk_dart_wire_wallet_utxos(port_: i64, that: *mut wire_cst_wallet) {
+    wire_wallet_utxos_impl(port_, that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_lwk_dart_rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(
     ptr: *const std::ffi::c_void,
 ) {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -405,6 +405,24 @@ fn wire_wallet_txs_impl(
         },
     )
 }
+fn wire_wallet_utxos_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: impl CstDecode<crate::api::wallet::Wallet>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_utxos",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            move |context| {
+                transform_result_dco((move || crate::api::wallet::Wallet::utxos(&api_that))())
+            }
+        },
+    )
+}
 
 // Section: dart2rust
 

--- a/rust/src/frb_generated.web.rs
+++ b/rust/src/frb_generated.web.rs
@@ -503,6 +503,14 @@ pub fn wire_wallet_txs(
 }
 
 #[wasm_bindgen]
+pub fn wire_wallet_utxos(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+) {
+    wire_wallet_utxos_impl(port_, that)
+}
+
+#[wasm_bindgen]
 pub fn rust_arc_increment_strong_count_RustOpaque_Mutexlwk_wolletWollet(
     ptr: *const std::ffi::c_void,
 ) {

--- a/test/lwk_root_test.dart
+++ b/test/lwk_root_test.dart
@@ -47,6 +47,8 @@ void main() {
       await wallet.sync(electrumUrl: electrumUrl);
       final postBalance = await wallet.balances();
       print('Post Balance: ${postBalance}');
+      final getUnspendUtxos = await wallet.utxos();
+      print('Unspent Utxos: $getUnspendUtxos');
     });
   });
 }


### PR DESCRIPTION
This is done so we can access the LwkError class when handling errors, and access the message and get a result like "Insuficcient funds" instead of "LwkError(msg: Insufficient funds)"

This keeps the same behaviour it was before the updates, and we can do something of the sort

<img width="523" alt="image" src="https://github.com/SatoshiPortal/lwk-dart/assets/47111823/cea36bb8-dc8c-4aa6-8228-0accfb996fb0">
