### PR TITLE
fix: flutter_rust_bridge version compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   ffi: ^2.0.1
-  flutter_rust_bridge: 2.0.0
+  flutter_rust_bridge: ^2.0.0
   meta: ^1.8.0
   uuid: ^4.1.0
   dio: ^5.4.0


### PR DESCRIPTION
Hey there,

I would like to ask if there is any reason to restrict `flutter_rust_bridge` between `>=2.0.0` and `<2.1.0` instead of `^2.0.0` or `^2.1.0` ?

This create incompatibility with packages that rely on more updated versions of `flutter_rust_bridge`, currently `^2.6.0`

Example:
```sh
flutter pub add bip85

Because every version of bip85 depends on flutter_rust_bridge ^2.6.0 and every version of lwk_dart
  from git depends on flutter_rust_bridge 2.0.0, bip85 is incompatible with lwk_dart from git.
So, because bb_mobile depends on both lwk_dart from git and bip85 any, version solving failed.
```