### PR TITLE
Ability to detect and spend unblinded addresses

### DIFF
--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -56,7 +56,7 @@ impl From<AssetIdBTreeMapInt> for Balances {
             .into_iter()
             .map(|(key, value)| Balance {
                 asset_id: key.to_string(),
-                value: value as u64,
+                value: value,
                 blinded: true,
             })
             .collect()
@@ -69,7 +69,7 @@ impl From<AssetIdHashMapInt> for Balances {
             .into_iter()
             .map(|(key, value)| Balance {
                 asset_id: key.to_string(),
-                value: value as u64,
+                value: value,
                 blinded: true,
             })
             .collect()
@@ -83,13 +83,18 @@ impl From<AssetIdBTreeMapUInt> for Balances {
         asset_id_map
             .0
             .into_iter()
-            .map(|(key, value)| {
-                Balance {
+            .filter_map(|(key, value)| match i64::try_from(value) {
+                Ok(converted_value) => Some(Balance {
                     asset_id: key.to_string(),
-                    value,
+                    value: converted_value,
                     blinded: true,
+                }),
+                Err(_) => {
+                    eprintln!("Warning: Overflow encountered converting {} to i64", value);
+                    None
                 }
-            }).collect()
+            })
+            .collect()
     }
 }
 
@@ -116,7 +121,7 @@ impl From<WalletTxOut> for TxOut {
 #[frb(dart_metadata=("freezed"))]
 pub struct Balance {
     pub asset_id: String,
-    pub value: u64,
+    pub value: i64,
     pub blinded: bool,
 }
 

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -56,7 +56,8 @@ impl From<AssetIdBTreeMapInt> for Balances {
             .into_iter()
             .map(|(key, value)| Balance {
                 asset_id: key.to_string(),
-                value,
+                value: value as u64,
+                blinded: true,
             })
             .collect()
     }
@@ -68,13 +69,12 @@ impl From<AssetIdHashMapInt> for Balances {
             .into_iter()
             .map(|(key, value)| Balance {
                 asset_id: key.to_string(),
-                value,
+                value: value as u64,
+                blinded: true,
             })
             .collect()
     }
 }
-
-use std::convert::TryFrom;
 
 use super::error::LwkError;
 
@@ -83,17 +83,13 @@ impl From<AssetIdBTreeMapUInt> for Balances {
         asset_id_map
             .0
             .into_iter()
-            .filter_map(|(key, value)| match i64::try_from(value) {
-                Ok(converted_value) => Some(Balance {
+            .map(|(key, value)| {
+                Balance {
                     asset_id: key.to_string(),
-                    value: converted_value,
-                }),
-                Err(_) => {
-                    eprintln!("Warning: Overflow encountered converting {} to i64", value);
-                    None
+                    value,
+                    blinded: true,
                 }
-            })
-            .collect()
+            }).collect()
     }
 }
 
@@ -120,7 +116,8 @@ impl From<WalletTxOut> for TxOut {
 #[frb(dart_metadata=("freezed"))]
 pub struct Balance {
     pub asset_id: String,
-    pub value: i64,
+    pub value: u64,
+    pub blinded: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
* Added `blinded: bool` field, false means unblinded.
* created `build_unblinded_tx` function, to spend unblinded utxos

Have changed the type of value in Balance to u64, as conversion from
i64 to u64 always succeeds and unsigned ints are the correct types for amounts.

Given default `blinded: true` from conversions from `AssetIdTreeMap` types to `Balances`.