### PR TITLE
feat: expose baseUrl in build_payjoin_tx

### DIFF
--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -180,7 +180,8 @@ void frbgen_lwk_wire__crate__api__wallet__wallet_build_payjoin_tx(int64_t port_,
                                                                   uint64_t sats,
                                                                   struct wire_cst_list_prim_u_8_strict *out_address,
                                                                   struct wire_cst_list_prim_u_8_strict *asset,
-                                                                  int32_t network);
+                                                                  int32_t network,
+                                                                  struct wire_cst_list_prim_u_8_strict *base_url);
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_decode_tx(int64_t port_,
                                                            struct wire_cst_wallet *that,

--- a/lib/src/generated/api/wallet.dart
+++ b/lib/src/generated/api/wallet.dart
@@ -85,13 +85,15 @@ class Wallet {
           {required BigInt sats,
           required String outAddress,
           required String asset,
-          required Network network}) =>
+          required Network network,
+          String? baseUrl}) =>
       LwkCore.instance.api.crateApiWalletWalletBuildPayjoinTx(
           that: this,
           sats: sats,
           outAddress: outAddress,
           asset: asset,
-          network: network);
+          network: network,
+          baseUrl: baseUrl);
 
   /// Decode a transaction given a PSET
   Future<PsetAmounts> decodeTx({required String pset}) =>

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -132,7 +132,8 @@ abstract class LwkCoreApi extends BaseApi {
       required BigInt sats,
       required String outAddress,
       required String asset,
-      required Network network});
+      required Network network,
+      String? baseUrl});
 
   Future<PsetAmounts> crateApiWalletWalletDecodeTx(
       {required Wallet that, required String pset});
@@ -555,7 +556,8 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
       required BigInt sats,
       required String outAddress,
       required String asset,
-      required Network network}) {
+      required Network network,
+      String? baseUrl}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_box_autoadd_wallet(that);
@@ -563,15 +565,16 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
         var arg2 = cst_encode_String(outAddress);
         var arg3 = cst_encode_String(asset);
         var arg4 = cst_encode_network(network);
+        var arg5 = cst_encode_opt_String(baseUrl);
         return wire.wire__crate__api__wallet__wallet_build_payjoin_tx(
-            port_, arg0, arg1, arg2, arg3, arg4);
+            port_, arg0, arg1, arg2, arg3, arg4, arg5);
       },
       codec: DcoCodec(
         decodeSuccessData: dco_decode_payjoin_tx,
         decodeErrorData: dco_decode_lwk_error,
       ),
       constMeta: kCrateApiWalletWalletBuildPayjoinTxConstMeta,
-      argValues: [that, sats, outAddress, asset, network],
+      argValues: [that, sats, outAddress, asset, network, baseUrl],
       apiImpl: this,
     ));
   }
@@ -579,7 +582,7 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
   TaskConstMeta get kCrateApiWalletWalletBuildPayjoinTxConstMeta =>
       const TaskConstMeta(
         debugName: "wallet_build_payjoin_tx",
-        argNames: ["that", "sats", "outAddress", "asset", "network"],
+        argNames: ["that", "sats", "outAddress", "asset", "network", "baseUrl"],
       );
 
   @override

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -985,6 +985,7 @@ class LwkCoreWire implements BaseWire {
     ffi.Pointer<wire_cst_list_prim_u_8_strict> out_address,
     ffi.Pointer<wire_cst_list_prim_u_8_strict> asset,
     int network,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> base_url,
   ) {
     return _wire__crate__api__wallet__wallet_build_payjoin_tx(
       port_,
@@ -993,6 +994,7 @@ class LwkCoreWire implements BaseWire {
       out_address,
       asset,
       network,
+      base_url,
     );
   }
 
@@ -1004,7 +1006,8 @@ class LwkCoreWire implements BaseWire {
                   ffi.Uint64,
                   ffi.Pointer<wire_cst_list_prim_u_8_strict>,
                   ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-                  ffi.Int32)>>(
+                  ffi.Int32,
+                  ffi.Pointer<wire_cst_list_prim_u_8_strict>)>>(
       'frbgen_lwk_wire__crate__api__wallet__wallet_build_payjoin_tx');
   late final _wire__crate__api__wallet__wallet_build_payjoin_tx =
       _wire__crate__api__wallet__wallet_build_payjoin_txPtr.asFunction<
@@ -1014,7 +1017,8 @@ class LwkCoreWire implements BaseWire {
               int,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              int)>();
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>)>();
 
   void wire__crate__api__wallet__wallet_decode_tx(
     int port_,

--- a/lib/src/generated/frb_generated.web.dart
+++ b/lib/src/generated/frb_generated.web.dart
@@ -681,9 +681,10 @@ class LwkCoreWire implements BaseWire {
           JSAny sats,
           String out_address,
           String asset,
-          int network) =>
+          int network,
+          String? base_url) =>
       wasmModule.wire__crate__api__wallet__wallet_build_payjoin_tx(
-          port_, that, sats, out_address, asset, network);
+          port_, that, sats, out_address, asset, network, base_url);
 
   void wire__crate__api__wallet__wallet_decode_tx(
           NativePortType port_, JSAny that, String pset) =>
@@ -802,7 +803,8 @@ extension type LwkCoreWasmModule._(JSObject _) implements JSObject {
       JSAny sats,
       String out_address,
       String asset,
-      int network);
+      int network,
+      String? base_url);
 
   external void wire__crate__api__wallet__wallet_decode_tx(
       NativePortType port_, JSAny that, String pset);

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -180,7 +180,8 @@ void frbgen_lwk_wire__crate__api__wallet__wallet_build_payjoin_tx(int64_t port_,
                                                                   uint64_t sats,
                                                                   struct wire_cst_list_prim_u_8_strict *out_address,
                                                                   struct wire_cst_list_prim_u_8_strict *asset,
-                                                                  int32_t network);
+                                                                  int32_t network,
+                                                                  struct wire_cst_list_prim_u_8_strict *base_url);
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_decode_tx(int64_t port_,
                                                            struct wire_cst_wallet *that,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -189,6 +189,7 @@ impl Wallet {
         out_address: String,
         asset: String,
         network: Network,
+        base_url: Option<String>,
     ) -> anyhow::Result<super::types::PayjoinTx, LwkError> {
         let wallet = self.get_wallet()?;
 
@@ -208,7 +209,7 @@ impl Wallet {
             next_index: None,
         };
 
-        let (network, base_url) = match network {
+        let (network, default_base_url) = match network {
             Network::Mainnet => (
                 sideswap_common::network::Network::Liquid,
                 sideswap_payjoin::BASE_URL_PROD,
@@ -218,6 +219,9 @@ impl Wallet {
                 sideswap_payjoin::BASE_URL_TESTNET,
             ),
         };
+
+        // Use provided base_url or fall back to default
+        let base_url = base_url.unwrap_or_else(|| default_base_url.to_owned());
 
         let asset = lwk_wollet::elements::AssetId::from_str(&asset)?;
         let out_address = lwk_wollet::elements::Address::from_str(&out_address)?;
@@ -240,7 +244,7 @@ impl Wallet {
             &mut payjoin_wallet,
             sideswap_payjoin::CreatePayjoin {
                 network,
-                base_url: base_url.to_owned(),
+                base_url,
                 user_agent: "lwk-dart".to_owned(),
                 utxos,
                 multisig_wallet: false,
@@ -589,7 +593,7 @@ mod tests {
         );
 
         let payjoin = wallet
-            .build_payjoin_tx(10000, out_address, asset.to_owned(), network)
+            .build_payjoin_tx(10000, out_address, asset.to_owned(), network, None)
             .unwrap();
         println!("asset_fee: {}", payjoin.asset_fee);
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -403,6 +403,7 @@ fn wire__crate__api__wallet__wallet_build_payjoin_tx_impl(
     out_address: impl CstDecode<String>,
     asset: impl CstDecode<String>,
     network: impl CstDecode<crate::api::types::Network>,
+    base_url: impl CstDecode<Option<String>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -416,6 +417,7 @@ fn wire__crate__api__wallet__wallet_build_payjoin_tx_impl(
             let api_out_address = out_address.cst_decode();
             let api_asset = asset.cst_decode();
             let api_network = network.cst_decode();
+            let api_base_url = base_url.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::api::error::LwkError>((move || {
                     let output_ok = crate::api::wallet::Wallet::build_payjoin_tx(
@@ -424,6 +426,7 @@ fn wire__crate__api__wallet__wallet_build_payjoin_tx_impl(
                         api_out_address,
                         api_asset,
                         api_network,
+                        api_base_url,
                     )?;
                     Ok(output_ok)
                 })())
@@ -2172,6 +2175,7 @@ mod io {
         out_address: *mut wire_cst_list_prim_u_8_strict,
         asset: *mut wire_cst_list_prim_u_8_strict,
         network: i32,
+        base_url: *mut wire_cst_list_prim_u_8_strict,
     ) {
         wire__crate__api__wallet__wallet_build_payjoin_tx_impl(
             port_,
@@ -2180,6 +2184,7 @@ mod io {
             out_address,
             asset,
             network,
+            base_url,
         )
     }
 
@@ -3079,6 +3084,7 @@ mod web {
         out_address: String,
         asset: String,
         network: i32,
+        base_url: Option<String>,
     ) {
         wire__crate__api__wallet__wallet_build_payjoin_tx_impl(
             port_,
@@ -3087,6 +3093,7 @@ mod web {
             out_address,
             asset,
             network,
+            base_url,
         )
     }
 


### PR DESCRIPTION
In AQUA, to support subsidised TXs, we need an option to configure the BaseURL that we use to get USDT UTXOs in build_payjoin_tx. This PR makes those changes