### PR TITLE
Return TxOutSecrets from build_payjoin_tx

### DIFF
--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -146,6 +146,11 @@ typedef struct wire_cst_list_tx_input {
   int32_t len;
 } wire_cst_list_tx_input;
 
+typedef struct wire_cst_list_tx_out_secrets {
+  struct wire_cst_tx_out_secrets *ptr;
+  int32_t len;
+} wire_cst_list_tx_out_secrets;
+
 typedef struct wire_cst_list_tx_output {
   struct wire_cst_tx_output *ptr;
   int32_t len;
@@ -159,6 +164,7 @@ typedef struct wire_cst_payjoin_tx {
   struct wire_cst_list_prim_u_8_strict *pset;
   uint64_t network_fee;
   uint64_t asset_fee;
+  struct wire_cst_list_tx_out_secrets *unblinded_outputs;
 } wire_cst_payjoin_tx;
 
 typedef struct wire_cst_pset_amounts {
@@ -411,6 +417,8 @@ struct wire_cst_list_tx_input *frbgen_lwk_cst_new_list_tx_input(int32_t len);
 
 struct wire_cst_list_tx_out *frbgen_lwk_cst_new_list_tx_out(int32_t len);
 
+struct wire_cst_list_tx_out_secrets *frbgen_lwk_cst_new_list_tx_out_secrets(int32_t len);
+
 struct wire_cst_list_tx_output *frbgen_lwk_cst_new_list_tx_output(int32_t len);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
@@ -433,6 +441,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_input);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_out);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_out_secrets);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_output);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_rust_arc_decrement_strong_count_RustOpaque_Mutexlwk_wolletWollet);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLiquidTransaction);

--- a/lib/src/generated/api/types.dart
+++ b/lib/src/generated/api/types.dart
@@ -8,7 +8,7 @@ import 'error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `AssetIdBTreeMapInt`, `AssetIdBTreeMapUInt`, `AssetIdHashMapInt`, `AssetIdHashMapUInt`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `into`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `into`, `try_from`
 
 /// Address class which contains both standard and confidential addresses with the address index in the wallet
 class Address {
@@ -114,14 +114,22 @@ class PayjoinTx {
   /// Asset fee amount paid to the server
   final BigInt assetFee;
 
+  /// All unblinded outputs
+  final List<TxOutSecrets> unblindedOutputs;
+
   const PayjoinTx({
     required this.pset,
     required this.networkFee,
     required this.assetFee,
+    required this.unblindedOutputs,
   });
 
   @override
-  int get hashCode => pset.hashCode ^ networkFee.hashCode ^ assetFee.hashCode;
+  int get hashCode =>
+      pset.hashCode ^
+      networkFee.hashCode ^
+      assetFee.hashCode ^
+      unblindedOutputs.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -130,7 +138,8 @@ class PayjoinTx {
           runtimeType == other.runtimeType &&
           pset == other.pset &&
           networkFee == other.networkFee &&
-          assetFee == other.assetFee;
+          assetFee == other.assetFee &&
+          unblindedOutputs == other.unblindedOutputs;
 }
 
 /// Decoded PSET amounts

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -2320,6 +2320,12 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
   }
 
   @protected
+  List<TxOutSecrets> dco_decode_list_tx_out_secrets(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_tx_out_secrets).toList();
+  }
+
+  @protected
   List<TxOutput> dco_decode_list_tx_output(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_tx_output).toList();
@@ -2406,12 +2412,13 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
   PayjoinTx dco_decode_payjoin_tx(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return PayjoinTx(
       pset: dco_decode_String(arr[0]),
       networkFee: dco_decode_u_64(arr[1]),
       assetFee: dco_decode_u_64(arr[2]),
+      unblindedOutputs: dco_decode_list_tx_out_secrets(arr[3]),
     );
   }
 
@@ -2875,6 +2882,19 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
   }
 
   @protected
+  List<TxOutSecrets> sse_decode_list_tx_out_secrets(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <TxOutSecrets>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_tx_out_secrets(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<TxOutput> sse_decode_list_tx_output(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -3004,8 +3024,12 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
     var var_pset = sse_decode_String(deserializer);
     var var_networkFee = sse_decode_u_64(deserializer);
     var var_assetFee = sse_decode_u_64(deserializer);
+    var var_unblindedOutputs = sse_decode_list_tx_out_secrets(deserializer);
     return PayjoinTx(
-        pset: var_pset, networkFee: var_networkFee, assetFee: var_assetFee);
+        pset: var_pset,
+        networkFee: var_networkFee,
+        assetFee: var_assetFee,
+        unblindedOutputs: var_unblindedOutputs);
   }
 
   @protected
@@ -3556,6 +3580,16 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
   }
 
   @protected
+  void sse_encode_list_tx_out_secrets(
+      List<TxOutSecrets> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_tx_out_secrets(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_tx_output(
       List<TxOutput> self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -3674,6 +3708,7 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
     sse_encode_String(self.pset, serializer);
     sse_encode_u_64(self.networkFee, serializer);
     sse_encode_u_64(self.assetFee, serializer);
+    sse_encode_list_tx_out_secrets(self.unblindedOutputs, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -153,6 +153,9 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   List<TxOut> dco_decode_list_tx_out(dynamic raw);
 
   @protected
+  List<TxOutSecrets> dco_decode_list_tx_out_secrets(dynamic raw);
+
+  @protected
   List<TxOutput> dco_decode_list_tx_output(dynamic raw);
 
   @protected
@@ -353,6 +356,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   List<TxOut> sse_decode_list_tx_out(SseDeserializer deserializer);
+
+  @protected
+  List<TxOutSecrets> sse_decode_list_tx_out_secrets(
+      SseDeserializer deserializer);
 
   @protected
   List<TxOutput> sse_decode_list_tx_output(SseDeserializer deserializer);
@@ -624,6 +631,17 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_list_tx_out_secrets> cst_encode_list_tx_out_secrets(
+      List<TxOutSecrets> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_tx_out_secrets(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_tx_out_secrets(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_list_tx_output> cst_encode_list_tx_output(
       List<TxOutput> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -778,6 +796,8 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
     wireObj.pset = cst_encode_String(apiObj.pset);
     wireObj.network_fee = cst_encode_u_64(apiObj.networkFee);
     wireObj.asset_fee = cst_encode_u_64(apiObj.assetFee);
+    wireObj.unblinded_outputs =
+        cst_encode_list_tx_out_secrets(apiObj.unblindedOutputs);
   }
 
   @protected
@@ -1045,6 +1065,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   void sse_encode_list_tx_out(List<TxOut> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_tx_out_secrets(
+      List<TxOutSecrets> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_tx_output(List<TxOutput> self, SseSerializer serializer);
@@ -2753,6 +2777,19 @@ class LwkCoreWire implements BaseWire {
   late final _cst_new_list_tx_out = _cst_new_list_tx_outPtr
       .asFunction<ffi.Pointer<wire_cst_list_tx_out> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_tx_out_secrets> cst_new_list_tx_out_secrets(
+    int len,
+  ) {
+    return _cst_new_list_tx_out_secrets(len);
+  }
+
+  late final _cst_new_list_tx_out_secretsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_tx_out_secrets> Function(
+              ffi.Int32)>>('frbgen_lwk_cst_new_list_tx_out_secrets');
+  late final _cst_new_list_tx_out_secrets = _cst_new_list_tx_out_secretsPtr
+      .asFunction<ffi.Pointer<wire_cst_list_tx_out_secrets> Function(int)>();
+
   ffi.Pointer<wire_cst_list_tx_output> cst_new_list_tx_output(int len) {
     return _cst_new_list_tx_output(len);
   }
@@ -2978,6 +3015,13 @@ final class wire_cst_list_tx_input extends ffi.Struct {
   external int len;
 }
 
+final class wire_cst_list_tx_out_secrets extends ffi.Struct {
+  external ffi.Pointer<wire_cst_tx_out_secrets> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_list_tx_output extends ffi.Struct {
   external ffi.Pointer<wire_cst_tx_output> ptr;
 
@@ -2997,6 +3041,8 @@ final class wire_cst_payjoin_tx extends ffi.Struct {
 
   @ffi.Uint64()
   external int asset_fee;
+
+  external ffi.Pointer<wire_cst_list_tx_out_secrets> unblinded_outputs;
 }
 
 final class wire_cst_pset_amounts extends ffi.Struct {

--- a/lib/src/generated/frb_generated.web.dart
+++ b/lib/src/generated/frb_generated.web.dart
@@ -155,6 +155,9 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   List<TxOut> dco_decode_list_tx_out(dynamic raw);
 
   @protected
+  List<TxOutSecrets> dco_decode_list_tx_out_secrets(dynamic raw);
+
+  @protected
   List<TxOutput> dco_decode_list_tx_output(dynamic raw);
 
   @protected
@@ -355,6 +358,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   List<TxOut> sse_decode_list_tx_out(SseDeserializer deserializer);
+
+  @protected
+  List<TxOutSecrets> sse_decode_list_tx_out_secrets(
+      SseDeserializer deserializer);
 
   @protected
   List<TxOutput> sse_decode_list_tx_output(SseDeserializer deserializer);
@@ -599,6 +606,12 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   }
 
   @protected
+  JSAny cst_encode_list_tx_out_secrets(List<TxOutSecrets> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_tx_out_secrets).toList().jsify()!;
+  }
+
+  @protected
   JSAny cst_encode_list_tx_output(List<TxOutput> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw.map(cst_encode_tx_output).toList().jsify()!;
@@ -670,7 +683,8 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
     return [
       cst_encode_String(raw.pset),
       cst_encode_u_64(raw.networkFee),
-      cst_encode_u_64(raw.assetFee)
+      cst_encode_u_64(raw.assetFee),
+      cst_encode_list_tx_out_secrets(raw.unblindedOutputs)
     ].jsify()!;
   }
 
@@ -970,6 +984,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   void sse_encode_list_tx_out(List<TxOut> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_tx_out_secrets(
+      List<TxOutSecrets> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_tx_output(List<TxOutput> self, SseSerializer serializer);

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -146,6 +146,11 @@ typedef struct wire_cst_list_tx_input {
   int32_t len;
 } wire_cst_list_tx_input;
 
+typedef struct wire_cst_list_tx_out_secrets {
+  struct wire_cst_tx_out_secrets *ptr;
+  int32_t len;
+} wire_cst_list_tx_out_secrets;
+
 typedef struct wire_cst_list_tx_output {
   struct wire_cst_tx_output *ptr;
   int32_t len;
@@ -159,6 +164,7 @@ typedef struct wire_cst_payjoin_tx {
   struct wire_cst_list_prim_u_8_strict *pset;
   uint64_t network_fee;
   uint64_t asset_fee;
+  struct wire_cst_list_tx_out_secrets *unblinded_outputs;
 } wire_cst_payjoin_tx;
 
 typedef struct wire_cst_pset_amounts {
@@ -411,6 +417,8 @@ struct wire_cst_list_tx_input *frbgen_lwk_cst_new_list_tx_input(int32_t len);
 
 struct wire_cst_list_tx_out *frbgen_lwk_cst_new_list_tx_out(int32_t len);
 
+struct wire_cst_list_tx_out_secrets *frbgen_lwk_cst_new_list_tx_out_secrets(int32_t len);
+
 struct wire_cst_list_tx_output *frbgen_lwk_cst_new_list_tx_output(int32_t len);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
@@ -433,6 +441,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_input);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_out);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_out_secrets);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_cst_new_list_tx_output);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_rust_arc_decrement_strong_count_RustOpaque_Mutexlwk_wolletWollet);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLiquidTransaction);

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "gdk-pin-client"
 version = "0.1.0"
-source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=f81c508eb3a2a7d6f64a9cd72063a6a55753cce3#f81c508eb3a2a7d6f64a9cd72063a6a55753cce3"
+source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=d91bd0497c7093f677247f16c35f486c34dd29f9#d91bd0497c7093f677247f16c35f486c34dd29f9"
 dependencies = [
  "aes 0.7.5",
  "bitcoin",
@@ -2249,6 +2249,7 @@ dependencies = [
  "lwk_wollet",
  "sideswap_common",
  "sideswap_payjoin",
+ "sideswap_types",
  "thiserror 1.0.69",
 ]
 
@@ -3351,7 +3352,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sideswap_api"
 version = "0.1.2"
-source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=f81c508eb3a2a7d6f64a9cd72063a6a55753cce3#f81c508eb3a2a7d6f64a9cd72063a6a55753cce3"
+source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=d91bd0497c7093f677247f16c35f486c34dd29f9#d91bd0497c7093f677247f16c35f486c34dd29f9"
 dependencies = [
  "elements",
  "hex",
@@ -3365,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "sideswap_common"
 version = "0.1.2"
-source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=f81c508eb3a2a7d6f64a9cd72063a6a55753cce3#f81c508eb3a2a7d6f64a9cd72063a6a55753cce3"
+source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=d91bd0497c7093f677247f16c35f486c34dd29f9#d91bd0497c7093f677247f16c35f486c34dd29f9"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -3402,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "sideswap_payjoin"
 version = "0.1.2"
-source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=f81c508eb3a2a7d6f64a9cd72063a6a55753cce3#f81c508eb3a2a7d6f64a9cd72063a6a55753cce3"
+source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=d91bd0497c7093f677247f16c35f486c34dd29f9#d91bd0497c7093f677247f16c35f486c34dd29f9"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3410,17 +3411,24 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sideswap_common",
+ "sideswap_types",
  "ureq",
 ]
 
 [[package]]
 name = "sideswap_types"
 version = "0.1.2"
-source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=f81c508eb3a2a7d6f64a9cd72063a6a55753cce3#f81c508eb3a2a7d6f64a9cd72063a6a55753cce3"
+source = "git+https://github.com/sideswap-io/sideswap_rust.git?rev=d91bd0497c7093f677247f16c35f486c34dd29f9#d91bd0497c7093f677247f16c35f486c34dd29f9"
 dependencies = [
+ "base64 0.21.7",
  "elements",
+ "hex",
+ "hex-literal",
+ "rand 0.8.5",
  "serde",
+ "serde_bytes",
  "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [lib]
 name = "lwk"
 doctest = false
-crate-type = ["staticlib", "cdylib"] 
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 lwk_wollet = {version = "0.9.0" }
@@ -20,8 +20,9 @@ anyhow = "1.0.68"
 lazy_static = "1.4.0"
 hex = "0.4"
 log = "0.4.22"
-sideswap_common = { git = "https://github.com/sideswap-io/sideswap_rust.git", rev = "f81c508eb3a2a7d6f64a9cd72063a6a55753cce3" }
-sideswap_payjoin = { git = "https://github.com/sideswap-io/sideswap_rust.git", rev = "f81c508eb3a2a7d6f64a9cd72063a6a55753cce3" }
+sideswap_types = { git = "https://github.com/sideswap-io/sideswap_rust.git", rev = "d91bd0497c7093f677247f16c35f486c34dd29f9" }
+sideswap_common = { git = "https://github.com/sideswap-io/sideswap_rust.git", rev = "d91bd0497c7093f677247f16c35f486c34dd29f9" }
+sideswap_payjoin = { git = "https://github.com/sideswap-io/sideswap_rust.git", rev = "d91bd0497c7093f677247f16c35f486c34dd29f9" }
 
 [build-dependencies]
 flutter_rust_bridge_codegen = { version = "=2.9.0" }

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -2,6 +2,7 @@ use flutter_rust_bridge::frb;
 use lwk_common::PsetBalance;
 use lwk_wollet::{
     elements::{
+        self,
         hex::{FromHex, ToHex},
         pset::PartiallySignedTransaction,
         Address as LwkAddress, AddressParams, AssetId, Script,
@@ -134,17 +135,23 @@ impl From<AssetIdHashMapUInt> for Balances {
     }
 }
 
+impl From<elements::TxOutSecrets> for TxOutSecrets {
+    fn from(value: elements::TxOutSecrets) -> Self {
+        TxOutSecrets {
+            value: value.value,
+            value_bf: value.value_bf.to_string(),
+            asset: value.asset.to_string(),
+            asset_bf: value.asset_bf.to_string(),
+        }
+    }
+}
+
 impl From<WalletTxOut> for TxOut {
     fn from(wallet_tx_out: WalletTxOut) -> Self {
         TxOut {
             script_pubkey: wallet_tx_out.script_pubkey.to_hex(),
             height: wallet_tx_out.height,
-            unblinded: TxOutSecrets {
-                value: wallet_tx_out.unblinded.value,
-                value_bf: wallet_tx_out.unblinded.value_bf.to_string(),
-                asset: wallet_tx_out.unblinded.asset.to_string(),
-                asset_bf: wallet_tx_out.unblinded.asset_bf.to_string(),
-            },
+            unblinded: wallet_tx_out.unblinded.into(),
             outpoint: OutPoint {
                 txid: wallet_tx_out.outpoint.txid.to_string(),
                 vout: wallet_tx_out.outpoint.vout,
@@ -290,12 +297,7 @@ impl From<WalletTx> for Tx {
                 outputs.push(TxOut {
                     script_pubkey: script_pubkey.to_hex(),
                     height: output.clone().unwrap().height,
-                    unblinded: TxOutSecrets {
-                        value: output.clone().unwrap().unblinded.value,
-                        value_bf: output.clone().unwrap().unblinded.value_bf.to_string(),
-                        asset: output.clone().unwrap().unblinded.asset.to_string(),
-                        asset_bf: output.clone().unwrap().unblinded.asset_bf.to_string(),
-                    },
+                    unblinded: output.as_ref().unwrap().unblinded.into(),
                     outpoint: OutPoint {
                         txid: output.clone().unwrap().outpoint.txid.to_string(),
                         vout: output.clone().unwrap().outpoint.vout,
@@ -313,12 +315,7 @@ impl From<WalletTx> for Tx {
                 inputs.push(TxOut {
                     script_pubkey: script_pubkey.to_string(),
                     height: input.clone().unwrap().height,
-                    unblinded: TxOutSecrets {
-                        value: input.clone().unwrap().unblinded.value,
-                        value_bf: input.clone().unwrap().unblinded.value_bf.to_string(),
-                        asset: input.clone().unwrap().unblinded.asset.to_string(),
-                        asset_bf: input.clone().unwrap().unblinded.asset_bf.to_string(),
-                    },
+                    unblinded: input.as_ref().unwrap().unblinded.into(),
                     outpoint: OutPoint {
                         txid: input.clone().unwrap().outpoint.txid.to_string(),
                         vout: input.clone().unwrap().outpoint.vout,
@@ -393,6 +390,8 @@ pub struct PayjoinTx {
     pub network_fee: u64,
     /// Asset fee amount paid to the server
     pub asset_fee: u64,
+    /// All unblinded outputs
+    pub unblinded_outputs: Vec<TxOutSecrets>,
 }
 
 // #[test]

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -231,16 +231,16 @@ impl Address {
                 Network::Testnet => &AddressParams::LIQUID_TESTNET,
             },
         );
-        if address.is_none() {
-            Err(LwkError {
-                msg: "Could not convert script to address".to_string(),
-            })
-        } else {
+        if let Some(address) = address {
             Ok(Address {
-                standard: address.clone().unwrap().to_unconfidential().to_string(),
-                confidential: address.unwrap().to_string(),
+                standard: address.to_unconfidential().to_string(),
+                confidential: address.to_string(),
                 index: None,
                 blinding_key: blinding_key,
+            })
+        } else {
+            Err(LwkError {
+                msg: "Could not convert script to address".to_string(),
             })
         }
     }
@@ -291,37 +291,35 @@ impl From<WalletTx> for Tx {
         let mut inputs: Vec<TxOut> = Vec::new();
 
         for output in &wallet_tx.outputs {
-            if output.is_some() {
-                // safe to unwrap
-                let script_pubkey = output.clone().unwrap().script_pubkey;
+            if let Some(output) = output {
+                let script_pubkey = output.script_pubkey.to_hex();
                 outputs.push(TxOut {
-                    script_pubkey: script_pubkey.to_hex(),
-                    height: output.clone().unwrap().height,
-                    unblinded: output.as_ref().unwrap().unblinded.into(),
+                    script_pubkey,
+                    height: output.height,
+                    unblinded: output.unblinded.into(),
                     outpoint: OutPoint {
-                        txid: output.clone().unwrap().outpoint.txid.to_string(),
-                        vout: output.clone().unwrap().outpoint.vout,
+                        txid: output.outpoint.txid.to_string(),
+                        vout: output.outpoint.vout,
                     },
-                    address: Address::from(output.clone().unwrap().address.clone()),
-                    is_spent: output.clone().unwrap().is_spent,
+                    address: Address::from(output.address.clone()),
+                    is_spent: output.is_spent,
                 })
             }
         }
 
         for input in &wallet_tx.inputs {
-            if input.is_some() {
-                // safe to unwrap
-                let script_pubkey = input.clone().unwrap().script_pubkey;
+            if let Some(input) = input {
+                let script_pubkey = input.script_pubkey.to_string();
                 inputs.push(TxOut {
-                    script_pubkey: script_pubkey.to_string(),
-                    height: input.clone().unwrap().height,
-                    unblinded: input.as_ref().unwrap().unblinded.into(),
+                    script_pubkey,
+                    height: input.height,
+                    unblinded: input.unblinded.into(),
                     outpoint: OutPoint {
-                        txid: input.clone().unwrap().outpoint.txid.to_string(),
-                        vout: input.clone().unwrap().outpoint.vout,
+                        txid: input.outpoint.txid.to_string(),
+                        vout: input.outpoint.vout,
                     },
-                    address: Address::from(input.clone().unwrap().address.clone()),
-                    is_spent: input.clone().unwrap().is_spent,
+                    address: Address::from(input.address.clone()),
+                    is_spent: input.is_spent,
                 })
             }
         }
@@ -333,7 +331,7 @@ impl From<WalletTx> for Tx {
             txid: wallet_tx.tx.txid().to_string().clone(),
             outputs: outputs,
             inputs: inputs,
-            fee: wallet_tx.fee.clone(),
+            fee: wallet_tx.fee,
             timestamp: wallet_tx.timestamp,
             height: wallet_tx.height,
             unblinded_url: wallet_tx.unblinded_url("").clone(),

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -222,29 +222,21 @@ impl Wallet {
     ) -> anyhow::Result<super::types::PayjoinTx, LwkError> {
         let wallet = self.get_wallet()?;
 
-        struct Wallet<'a> {
-            wallet: &'a lwk_wollet::Wollet,
-            next_index: Option<u32>,
-        }
-        impl<'a> sideswap_payjoin::Wallet for Wallet<'a> {
-            fn change_address(&mut self) -> Result<lwk_wollet::elements::Address, anyhow::Error> {
-                let address = self.wallet.change(self.next_index)?;
-                self.next_index = Some(address.index() + 1);
-                Ok(address.address().clone())
-            }
-        }
-        let mut payjoin_wallet = Wallet {
-            wallet: &wallet,
-            next_index: None,
+        let mut next_index: Option<u32> = None;
+
+        let mut change_cb = || -> Result<lwk_wollet::elements::Address, anyhow::Error> {
+            let address = wallet.change(next_index)?;
+            next_index = Some(address.index() + 1);
+            Ok(address.address().clone())
         };
 
         let (network, default_base_url) = match network {
             Network::Mainnet => (
-                sideswap_common::network::Network::Liquid,
+                sideswap_types::network::Network::Liquid,
                 sideswap_payjoin::BASE_URL_PROD,
             ),
             Network::Testnet => (
-                sideswap_common::network::Network::LiquidTestnet,
+                sideswap_types::network::Network::LiquidTestnet,
                 sideswap_payjoin::BASE_URL_TESTNET,
             ),
         };
@@ -258,25 +250,32 @@ impl Wallet {
         let utxos = wallet
             .utxos()?
             .into_iter()
-            .map(|utxo| sideswap_payjoin::Utxo {
-                txid: utxo.outpoint.txid,
-                vout: utxo.outpoint.vout,
-                asset_id: utxo.unblinded.asset,
-                value: utxo.unblinded.value,
-                asset_bf: utxo.unblinded.asset_bf,
-                value_bf: utxo.unblinded.value_bf,
-                script_pub_key: utxo.script_pubkey,
+            .map(|utxo| {
+                let wallet_type = if utxo.script_pubkey.is_v0_p2wpkh() {
+                    sideswap_common::utxo_select::WalletType::Native
+                } else {
+                    sideswap_common::utxo_select::WalletType::Nested
+                };
+                sideswap_payjoin::Utxo {
+                    txid: utxo.outpoint.txid,
+                    vout: utxo.outpoint.vout,
+                    asset_id: utxo.unblinded.asset,
+                    value: utxo.unblinded.value,
+                    asset_bf: utxo.unblinded.asset_bf,
+                    value_bf: utxo.unblinded.value_bf,
+                    script_pub_key: utxo.script_pubkey,
+                    wallet_type,
+                }
             })
             .collect::<Vec<_>>();
 
         let mut payjoin = sideswap_payjoin::create_payjoin(
-            &mut payjoin_wallet,
+            &mut change_cb,
             sideswap_payjoin::CreatePayjoin {
                 network,
                 base_url,
                 user_agent: "lwk-dart".to_owned(),
                 utxos,
-                multisig_wallet: false,
                 use_all_utxos: false,
                 recipients: vec![sideswap_common::recipient::Recipient {
                     address: out_address,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -296,6 +296,7 @@ impl Wallet {
             pset: payjoin.pset.to_string(),
             network_fee: payjoin.network_fee,
             asset_fee: payjoin.asset_fee,
+            unblinded_outputs: payjoin.tx_secrets.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -609,5 +610,24 @@ mod tests {
 
         let txid = Blockchain::broadcast_tx_bytes(electrum_url.to_owned(), tx_bytes).unwrap();
         println!("txid: {txid}");
+
+        let unblinded_values = payjoin
+            .unblinded_outputs
+            .into_iter()
+            .flat_map(|unblinded| {
+                [
+                    unblinded.value.to_string(),
+                    unblinded.asset.to_string(),
+                    unblinded.value_bf.to_string(),
+                    unblinded.asset_bf.to_string(),
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        let unblinded_values = unblinded_values.join(",");
+
+        let unblinded_link =
+            format!("https://blockstream.info/liquidtestnet/tx/{txid}/#blinded={unblinded_values}");
+        println!("unblinded_link: {unblinded_link}");
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2289,6 +2289,18 @@ impl SseDecode for Vec<crate::api::types::TxOut> {
     }
 }
 
+impl SseDecode for Vec<crate::api::types::TxOutSecrets> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::types::TxOutSecrets>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::transaction::TxOutput> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2435,10 +2447,13 @@ impl SseDecode for crate::api::types::PayjoinTx {
         let mut var_pset = <String>::sse_decode(deserializer);
         let mut var_networkFee = <u64>::sse_decode(deserializer);
         let mut var_assetFee = <u64>::sse_decode(deserializer);
+        let mut var_unblindedOutputs =
+            <Vec<crate::api::types::TxOutSecrets>>::sse_decode(deserializer);
         return crate::api::types::PayjoinTx {
             pset: var_pset,
             network_fee: var_networkFee,
             asset_fee: var_assetFee,
+            unblinded_outputs: var_unblindedOutputs,
         };
     }
 }
@@ -2825,6 +2840,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::types::PayjoinTx {
             self.pset.into_into_dart().into_dart(),
             self.network_fee.into_into_dart().into_dart(),
             self.asset_fee.into_into_dart().into_dart(),
+            self.unblinded_outputs.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -3252,6 +3268,16 @@ impl SseEncode for Vec<crate::api::types::TxOut> {
     }
 }
 
+impl SseEncode for Vec<crate::api::types::TxOutSecrets> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::types::TxOutSecrets>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::transaction::TxOutput> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3379,6 +3405,7 @@ impl SseEncode for crate::api::types::PayjoinTx {
         <String>::sse_encode(self.pset, serializer);
         <u64>::sse_encode(self.network_fee, serializer);
         <u64>::sse_encode(self.asset_fee, serializer);
+        <Vec<crate::api::types::TxOutSecrets>>::sse_encode(self.unblinded_outputs, serializer);
     }
 }
 
@@ -3806,6 +3833,16 @@ mod io {
             vec.into_iter().map(CstDecode::cst_decode).collect()
         }
     }
+    impl CstDecode<Vec<crate::api::types::TxOutSecrets>> for *mut wire_cst_list_tx_out_secrets {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::types::TxOutSecrets> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
     impl CstDecode<Vec<crate::api::transaction::TxOutput>> for *mut wire_cst_list_tx_output {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<crate::api::transaction::TxOutput> {
@@ -3840,6 +3877,7 @@ mod io {
                 pset: self.pset.cst_decode(),
                 network_fee: self.network_fee.cst_decode(),
                 asset_fee: self.asset_fee.cst_decode(),
+                unblinded_outputs: self.unblinded_outputs.cst_decode(),
             }
         }
     }
@@ -4037,6 +4075,7 @@ mod io {
                 pset: core::ptr::null_mut(),
                 network_fee: Default::default(),
                 asset_fee: Default::default(),
+                unblinded_outputs: core::ptr::null_mut(),
             }
         }
     }
@@ -4983,6 +5022,20 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_lwk_cst_new_list_tx_out_secrets(
+        len: i32,
+    ) -> *mut wire_cst_list_tx_out_secrets {
+        let wrap = wire_cst_list_tx_out_secrets {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_tx_out_secrets>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_lwk_cst_new_list_tx_output(len: i32) -> *mut wire_cst_list_tx_output {
         let wrap = wire_cst_list_tx_output {
             ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
@@ -5072,6 +5125,12 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_list_tx_out_secrets {
+        ptr: *mut wire_cst_tx_out_secrets,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_list_tx_output {
         ptr: *mut wire_cst_tx_output,
         len: i32,
@@ -5093,6 +5152,7 @@ mod io {
         pset: *mut wire_cst_list_prim_u_8_strict,
         network_fee: u64,
         asset_fee: u64,
+        unblinded_outputs: *mut wire_cst_list_tx_out_secrets,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -5378,6 +5438,18 @@ mod web {
                 .collect()
         }
     }
+    impl CstDecode<Vec<crate::api::types::TxOutSecrets>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::types::TxOutSecrets> {
+            self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap()
+                .iter()
+                .map(CstDecode::cst_decode)
+                .collect()
+        }
+    }
     impl CstDecode<Vec<crate::api::transaction::TxOutput>>
         for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
     {
@@ -5445,14 +5517,15 @@ mod web {
                 .unwrap();
             assert_eq!(
                 self_.length(),
-                3,
-                "Expected 3 elements, got {}",
+                4,
+                "Expected 4 elements, got {}",
                 self_.length()
             );
             crate::api::types::PayjoinTx {
                 pset: self_.get(0).cst_decode(),
                 network_fee: self_.get(1).cst_decode(),
                 asset_fee: self_.get(2).cst_decode(),
+                unblinded_outputs: self_.get(3).cst_decode(),
             }
         }
     }


### PR DESCRIPTION
There is a problem with payjoins transactions and unblinding. Wallets can't fully unblind transactions because some outputs are sent to the SideSwap server (e.g. the USDt fee and LBTC change). With this PR the UI could store the blinding factors and to later use them to construct a full unblinded link. The updated test demonstrates how this can be done.