### PR TITLE
Expose per-address Liquid blinding secret

### DIFF
--- a/ios/Classes/frb_generated.h
+++ b/ios/Classes/frb_generated.h
@@ -156,6 +156,11 @@ typedef struct wire_cst_list_tx_output {
   int32_t len;
 } wire_cst_list_tx_output;
 
+typedef struct wire_cst_address_with_blinding_secret {
+  struct wire_cst_address address;
+  struct wire_cst_list_prim_u_8_strict *blinding_secret;
+} wire_cst_address_with_blinding_secret;
+
 typedef struct wire_cst_lwk_error {
   struct wire_cst_list_prim_u_8_strict *msg;
 } wire_cst_lwk_error;
@@ -314,6 +319,10 @@ void frbgen_lwk_wire__crate__api__wallet__wallet_address(int64_t port_,
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_address_last_unused(int64_t port_,
                                                                      struct wire_cst_wallet *that);
+
+void frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret(int64_t port_,
+                                                                              struct wire_cst_wallet *that,
+                                                                              uint32_t index);
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_balances(int64_t port_,
                                                           struct wire_cst_wallet *that);
@@ -513,6 +522,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__types__get_ltest_balance);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address_last_unused);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_balances);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_blinding_key);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_build_asset_tx);

--- a/lib/src/generated/api/types.dart
+++ b/lib/src/generated/api/types.dart
@@ -76,6 +76,28 @@ class Address {
           blindingKey == other.blindingKey;
 }
 
+/// A wallet address paired with the secret blinding key derived for that address.
+class AddressWithBlindingSecret {
+  final Address address;
+  final String blindingSecret;
+
+  const AddressWithBlindingSecret({
+    required this.address,
+    required this.blindingSecret,
+  });
+
+  @override
+  int get hashCode => address.hashCode ^ blindingSecret.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AddressWithBlindingSecret &&
+          runtimeType == other.runtimeType &&
+          address == other.address &&
+          blindingSecret == other.blindingSecret;
+}
+
 /// Balance represents a balance of a specific asset
 class Balance {
   final String assetId;

--- a/lib/src/generated/api/wallet.dart
+++ b/lib/src/generated/api/wallet.dart
@@ -32,6 +32,12 @@ class Wallet {
         that: this,
       );
 
+  /// Get an address and the secret blinding key derived specifically for it.
+  Future<AddressWithBlindingSecret> addressWithBlindingSecret(
+          {required int index}) =>
+      LwkCore.instance.api.crateApiWalletWalletAddressWithBlindingSecret(
+          that: this, index: index);
+
   /// Get balances for a wallet.
   Future<List<Balance>> balances() =>
       LwkCore.instance.api.crateApiWalletWalletBalances(

--- a/lib/src/generated/frb_generated.dart
+++ b/lib/src/generated/frb_generated.dart
@@ -73,7 +73,7 @@ class LwkCore extends BaseEntrypoint<LwkCoreApi, LwkCoreApiImpl, LwkCoreWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 651086619;
+  int get rustContentHash => 1929226336;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -253,6 +253,10 @@ abstract class LwkCoreApi extends BaseApi {
       {required Wallet that, required int index});
 
   Future<Address> crateApiWalletWalletAddressLastUnused({required Wallet that});
+
+  Future<AddressWithBlindingSecret>
+      crateApiWalletWalletAddressWithBlindingSecret(
+          {required Wallet that, required int index});
 
   Future<List<Balance>> crateApiWalletWalletBalances({required Wallet that});
 
@@ -1816,6 +1820,34 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
       );
 
   @override
+  Future<AddressWithBlindingSecret>
+      crateApiWalletWalletAddressWithBlindingSecret(
+          {required Wallet that, required int index}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        var arg0 = cst_encode_box_autoadd_wallet(that);
+        var arg1 = cst_encode_u_32(index);
+        return wire
+            .wire__crate__api__wallet__wallet_address_with_blinding_secret(
+                port_, arg0, arg1);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_address_with_blinding_secret,
+        decodeErrorData: dco_decode_lwk_error,
+      ),
+      constMeta: kCrateApiWalletWalletAddressWithBlindingSecretConstMeta,
+      argValues: [that, index],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiWalletWalletAddressWithBlindingSecretConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_address_with_blinding_secret",
+        argNames: ["that", "index"],
+      );
+
+  @override
   Future<List<Balance>> crateApiWalletWalletBalances({required Wallet that}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -2291,6 +2323,19 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
       confidential: dco_decode_String(arr[1]),
       index: dco_decode_opt_box_autoadd_u_32(arr[2]),
       blindingKey: dco_decode_opt_String(arr[3]),
+    );
+  }
+
+  @protected
+  AddressWithBlindingSecret dco_decode_address_with_blinding_secret(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return AddressWithBlindingSecret(
+      address: dco_decode_address(arr[0]),
+      blindingSecret: dco_decode_String(arr[1]),
     );
   }
 
@@ -2821,6 +2866,16 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
         confidential: var_confidential,
         index: var_index,
         blindingKey: var_blindingKey);
+  }
+
+  @protected
+  AddressWithBlindingSecret sse_decode_address_with_blinding_secret(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_address = sse_decode_address(deserializer);
+    var var_blindingSecret = sse_decode_String(deserializer);
+    return AddressWithBlindingSecret(
+        address: var_address, blindingSecret: var_blindingSecret);
   }
 
   @protected
@@ -3533,6 +3588,14 @@ class LwkCoreApiImpl extends LwkCoreApiImplPlatform implements LwkCoreApi {
     sse_encode_String(self.confidential, serializer);
     sse_encode_opt_box_autoadd_u_32(self.index, serializer);
     sse_encode_opt_String(self.blindingKey, serializer);
+  }
+
+  @protected
+  void sse_encode_address_with_blinding_secret(
+      AddressWithBlindingSecret self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_address(self.address, serializer);
+    sse_encode_String(self.blindingSecret, serializer);
   }
 
   @protected

--- a/lib/src/generated/frb_generated.io.dart
+++ b/lib/src/generated/frb_generated.io.dart
@@ -75,6 +75,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   Address dco_decode_address(dynamic raw);
 
   @protected
+  AddressWithBlindingSecret dco_decode_address_with_blinding_secret(
+      dynamic raw);
+
+  @protected
   Balance dco_decode_balance(dynamic raw);
 
   @protected
@@ -278,6 +282,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   Address sse_decode_address(SseDeserializer deserializer);
+
+  @protected
+  AddressWithBlindingSecret sse_decode_address_with_blinding_secret(
+      SseDeserializer deserializer);
 
   @protected
   Balance sse_decode_balance(SseDeserializer deserializer);
@@ -726,6 +734,14 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_address_with_blinding_secret(
+      AddressWithBlindingSecret apiObj,
+      wire_cst_address_with_blinding_secret wireObj) {
+    cst_api_fill_to_wire_address(apiObj.address, wireObj.address);
+    wireObj.blinding_secret = cst_encode_String(apiObj.blindingSecret);
+  }
+
+  @protected
   void cst_api_fill_to_wire_balance(Balance apiObj, wire_cst_balance wireObj) {
     wireObj.asset_id = cst_encode_String(apiObj.assetId);
     wireObj.value = cst_encode_i_64(apiObj.value);
@@ -979,6 +995,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   void sse_encode_address(Address self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_address_with_blinding_secret(
+      AddressWithBlindingSecret self, SseSerializer serializer);
 
   @protected
   void sse_encode_balance(Balance self, SseSerializer serializer);
@@ -2174,6 +2194,29 @@ class LwkCoreWire implements BaseWire {
       _wire__crate__api__wallet__wallet_address_last_unusedPtr
           .asFunction<void Function(int, ffi.Pointer<wire_cst_wallet>)>();
 
+  void wire__crate__api__wallet__wallet_address_with_blinding_secret(
+    int port_,
+    ffi.Pointer<wire_cst_wallet> that,
+    int index,
+  ) {
+    return _wire__crate__api__wallet__wallet_address_with_blinding_secret(
+      port_,
+      that,
+      index,
+    );
+  }
+
+  late final _wire__crate__api__wallet__wallet_address_with_blinding_secretPtr =
+      _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Int64, ffi.Pointer<wire_cst_wallet>, ffi.Uint32)>>(
+    'frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret',
+  );
+  late final _wire__crate__api__wallet__wallet_address_with_blinding_secret =
+      _wire__crate__api__wallet__wallet_address_with_blinding_secretPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_cst_wallet>, int)>();
+
   void wire__crate__api__wallet__wallet_balances(
     int port_,
     ffi.Pointer<wire_cst_wallet> that,
@@ -3108,6 +3151,12 @@ final class wire_cst_list_tx_output extends ffi.Struct {
 
   @ffi.Int32()
   external int len;
+}
+
+final class wire_cst_address_with_blinding_secret extends ffi.Struct {
+  external wire_cst_address address;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> blinding_secret;
 }
 
 final class wire_cst_lwk_error extends ffi.Struct {

--- a/lib/src/generated/frb_generated.web.dart
+++ b/lib/src/generated/frb_generated.web.dart
@@ -77,6 +77,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   Address dco_decode_address(dynamic raw);
 
   @protected
+  AddressWithBlindingSecret dco_decode_address_with_blinding_secret(
+      dynamic raw);
+
+  @protected
   Balance dco_decode_balance(dynamic raw);
 
   @protected
@@ -282,6 +286,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
   Address sse_decode_address(SseDeserializer deserializer);
 
   @protected
+  AddressWithBlindingSecret sse_decode_address_with_blinding_secret(
+      SseDeserializer deserializer);
+
+  @protected
   Balance sse_decode_balance(SseDeserializer deserializer);
 
   @protected
@@ -463,6 +471,15 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
       cst_encode_String(raw.confidential),
       cst_encode_opt_box_autoadd_u_32(raw.index),
       cst_encode_opt_String(raw.blindingKey)
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_address_with_blinding_secret(AddressWithBlindingSecret raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_address(raw.address),
+      cst_encode_String(raw.blindingSecret)
     ].jsify()!;
   }
 
@@ -898,6 +915,10 @@ abstract class LwkCoreApiImplPlatform extends BaseApiImpl<LwkCoreWire> {
 
   @protected
   void sse_encode_address(Address self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_address_with_blinding_secret(
+      AddressWithBlindingSecret self, SseSerializer serializer);
 
   @protected
   void sse_encode_balance(Balance self, SseSerializer serializer);
@@ -1393,6 +1414,11 @@ class LwkCoreWire implements BaseWire {
       wasmModule.wire__crate__api__wallet__wallet_address_last_unused(
           port_, that);
 
+  void wire__crate__api__wallet__wallet_address_with_blinding_secret(
+          NativePortType port_, JSAny that, int index) =>
+      wasmModule.wire__crate__api__wallet__wallet_address_with_blinding_secret(
+          port_, that, index);
+
   void wire__crate__api__wallet__wallet_balances(
           NativePortType port_, JSAny that) =>
       wasmModule.wire__crate__api__wallet__wallet_balances(port_, that);
@@ -1702,6 +1728,9 @@ extension type LwkCoreWasmModule._(JSObject _) implements JSObject {
 
   external void wire__crate__api__wallet__wallet_address_last_unused(
       NativePortType port_, JSAny that);
+
+  external void wire__crate__api__wallet__wallet_address_with_blinding_secret(
+      NativePortType port_, JSAny that, int index);
 
   external void wire__crate__api__wallet__wallet_balances(
       NativePortType port_, JSAny that);

--- a/macos/Classes/frb_generated.h
+++ b/macos/Classes/frb_generated.h
@@ -156,6 +156,11 @@ typedef struct wire_cst_list_tx_output {
   int32_t len;
 } wire_cst_list_tx_output;
 
+typedef struct wire_cst_address_with_blinding_secret {
+  struct wire_cst_address address;
+  struct wire_cst_list_prim_u_8_strict *blinding_secret;
+} wire_cst_address_with_blinding_secret;
+
 typedef struct wire_cst_lwk_error {
   struct wire_cst_list_prim_u_8_strict *msg;
 } wire_cst_lwk_error;
@@ -314,6 +319,10 @@ void frbgen_lwk_wire__crate__api__wallet__wallet_address(int64_t port_,
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_address_last_unused(int64_t port_,
                                                                      struct wire_cst_wallet *that);
+
+void frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret(int64_t port_,
+                                                                              struct wire_cst_wallet *that,
+                                                                              uint32_t index);
 
 void frbgen_lwk_wire__crate__api__wallet__wallet_balances(int64_t port_,
                                                           struct wire_cst_wallet *that);
@@ -513,6 +522,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__types__get_ltest_balance);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address_last_unused);
+    dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_balances);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_blinding_key);
     dummy_var ^= ((int64_t) (void*) frbgen_lwk_wire__crate__api__wallet__wallet_build_asset_tx);

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -214,6 +214,12 @@ pub struct Address {
     pub blinding_key: Option<String>,
 }
 
+/// A wallet address paired with the secret blinding key derived for that address.
+pub struct AddressWithBlindingSecret {
+    pub address: Address,
+    pub blinding_secret: String,
+}
+
 impl From<AddressResult> for Address {
     fn from(address: AddressResult) -> Self {
         Address {

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -18,6 +18,7 @@ use std::sync::MutexGuard;
 use super::descriptor::Descriptor;
 use super::error::LwkError;
 use super::types::Address;
+use super::types::AddressWithBlindingSecret;
 use super::types::AssetIdBTreeMapUInt;
 use super::types::Balances;
 use super::types::LiquidNetwork;
@@ -109,6 +110,29 @@ impl Wallet {
     pub fn address(&self, index: u32) -> anyhow::Result<Address, LwkError> {
         let address: AddressResult = self.get_wallet()?.address(Some(index))?.into();
         Ok(address.into())
+    }
+
+    /// Get an address and the secret blinding key derived specifically for it.
+    pub fn address_with_blinding_secret(
+        &self,
+        index: u32,
+    ) -> anyhow::Result<AddressWithBlindingSecret, LwkError> {
+        let wallet = self.get_wallet()?;
+        let address: AddressResult = wallet.address(Some(index))?.into();
+        let blinding_secret = lwk_common::derive_blinding_key(
+            wallet.descriptor()?,
+            &address.address().script_pubkey(),
+        )
+        .ok_or_else(|| LwkError {
+            msg: "Wallet descriptor cannot derive an address blinding secret".to_string(),
+        })?
+        .display_secret()
+        .to_string();
+
+        Ok(AddressWithBlindingSecret {
+            address: address.into(),
+            blinding_secret,
+        })
     }
 
     /// Get balances for a wallet.
@@ -369,8 +393,48 @@ mod tests {
 
     use crate::api::blockchain::Blockchain;
     use crate::api::transaction::extract_tx_bytes;
+    use lwk_wollet::elements::secp256k1_zkp::{PublicKey, Secp256k1, SecretKey};
 
     use super::*;
+
+    #[test]
+    fn address_with_blinding_secret_matches_address_and_index() {
+        let mnemonic =
+            "umbrella response wide outer mystery drastic crew festival poet coconut error act";
+        let network = LiquidNetwork::Testnet;
+        let desc = Descriptor::new_confidential(network, mnemonic.to_string()).unwrap();
+        let dbpath = std::env::temp_dir().join(format!(
+            "lwk_address_blinding_secret_{}",
+            std::process::id()
+        ));
+        let wallet = Wallet::init(network, dbpath.to_string_lossy().into_owned(), desc).unwrap();
+
+        let first = wallet.address_with_blinding_secret(0).unwrap();
+        let second = wallet.address_with_blinding_secret(1).unwrap();
+
+        assert_eq!(first.blinding_secret.len(), 64);
+        assert!(first
+            .blinding_secret
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit()));
+
+        let secret = SecretKey::from_str(&first.blinding_secret).unwrap();
+        let public = PublicKey::from_secret_key(&Secp256k1::new(), &secret);
+        let public = public.to_string();
+        assert_eq!(
+            first.address.blinding_key.as_deref(),
+            Some(public.as_str())
+        );
+
+        assert_eq!(first.address.index, Some(0));
+        assert_eq!(second.address.index, Some(1));
+        assert_ne!(first.address.confidential, second.address.confidential);
+        assert_ne!(first.blinding_secret, second.blinding_secret);
+
+        drop(wallet);
+        let _ = std::fs::remove_dir_all(dbpath);
+    }
+
     #[test]
     fn testable_wallets() {
         let mnemonic =

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 651086619;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1929226336;
 
 // Section: executor
 
@@ -1728,6 +1728,31 @@ fn wire__crate__api__wallet__wallet_address_last_unused_impl(
         },
     )
 }
+fn wire__crate__api__wallet__wallet_address_with_blinding_secret_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: impl CstDecode<crate::api::wallet::Wallet>,
+    index: impl CstDecode<u32>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_address_with_blinding_secret",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            let api_index = index.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::api::error::LwkError>((move || {
+                    let output_ok = crate::api::wallet::Wallet::address_with_blinding_secret(
+                        &api_that, api_index,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__wallet_balances_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     that: impl CstDecode<crate::api::wallet::Wallet>,
@@ -2225,6 +2250,18 @@ impl SseDecode for crate::api::types::Address {
             confidential: var_confidential,
             index: var_index,
             blinding_key: var_blindingKey,
+        };
+    }
+}
+
+impl SseDecode for crate::api::types::AddressWithBlindingSecret {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_address = <crate::api::types::Address>::sse_decode(deserializer);
+        let mut var_blindingSecret = <String>::sse_decode(deserializer);
+        return crate::api::types::AddressWithBlindingSecret {
+            address: var_address,
+            blinding_secret: var_blindingSecret,
         };
     }
 }
@@ -2833,6 +2870,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::Address> for crate::ap
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::AddressWithBlindingSecret {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.address.into_into_dart().into_dart(),
+            self.blinding_secret.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::types::AddressWithBlindingSecret
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::AddressWithBlindingSecret>
+    for crate::api::types::AddressWithBlindingSecret
+{
+    fn into_into_dart(self) -> crate::api::types::AddressWithBlindingSecret {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::types::Balance {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3239,6 +3297,14 @@ impl SseEncode for crate::api::types::Address {
         <String>::sse_encode(self.confidential, serializer);
         <Option<u32>>::sse_encode(self.index, serializer);
         <Option<String>>::sse_encode(self.blinding_key, serializer);
+    }
+}
+
+impl SseEncode for crate::api::types::AddressWithBlindingSecret {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::types::Address>::sse_encode(self.address, serializer);
+        <String>::sse_encode(self.blinding_secret, serializer);
     }
 }
 
@@ -3757,6 +3823,17 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::api::types::AddressWithBlindingSecret>
+        for wire_cst_address_with_blinding_secret
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::types::AddressWithBlindingSecret {
+            crate::api::types::AddressWithBlindingSecret {
+                address: self.address.cst_decode(),
+                blinding_secret: self.blinding_secret.cst_decode(),
+            }
+        }
+    }
     impl CstDecode<crate::api::types::Balance> for wire_cst_balance {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::api::types::Balance {
@@ -4107,6 +4184,19 @@ mod io {
         }
     }
     impl Default for wire_cst_address {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_address_with_blinding_secret {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                address: Default::default(),
+                blinding_secret: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_address_with_blinding_secret {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -4767,6 +4857,15 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_lwk_wire__crate__api__wallet__wallet_address_with_blinding_secret(
+        port_: i64,
+        that: *mut wire_cst_wallet,
+        index: u32,
+    ) {
+        wire__crate__api__wallet__wallet_address_with_blinding_secret_impl(port_, that, index)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_lwk_wire__crate__api__wallet__wallet_balances(
         port_: i64,
         that: *mut wire_cst_wallet,
@@ -5195,6 +5294,12 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_address_with_blinding_secret {
+        address: wire_cst_address,
+        blinding_secret: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_balance {
         asset_id: *mut wire_cst_list_prim_u_8_strict,
         value: i64,
@@ -5429,6 +5534,26 @@ mod web {
                 confidential: self_.get(1).cst_decode(),
                 index: self_.get(2).cst_decode(),
                 blinding_key: self_.get(3).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::types::AddressWithBlindingSecret>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::types::AddressWithBlindingSecret {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                2,
+                "Expected 2 elements, got {}",
+                self_.length()
+            );
+            crate::api::types::AddressWithBlindingSecret {
+                address: self_.get(0).cst_decode(),
+                blinding_secret: self_.get(1).cst_decode(),
             }
         }
     }
@@ -6468,6 +6593,15 @@ mod web {
         that: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) {
         wire__crate__api__wallet__wallet_address_last_unused_impl(port_, that)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__wallet__wallet_address_with_blinding_secret(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        that: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        index: u32,
+    ) {
+        wire__crate__api__wallet__wallet_address_with_blinding_secret_impl(port_, that, index)
     }
 
     #[wasm_bindgen]

--- a/test/lwk_root_test.dart
+++ b/test/lwk_root_test.dart
@@ -1,9 +1,51 @@
 // ignore_for_file: avoid_print
 
+import 'dart:io';
+
 import 'package:lwk/lwk.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Wallet address blinding secret', () {
+    late Directory dbDirectory;
+
+    setUpAll(() async {
+      dbDirectory = await Directory.systemTemp.createTemp(
+        'lwk_address_blinding_secret_',
+      );
+      await LibLwk.init();
+    });
+
+    tearDownAll(() async {
+      await dbDirectory.delete(recursive: true);
+    });
+
+    test('is paired with the generated address', () async {
+      const mnemonic =
+          'umbrella response wide outer mystery drastic crew festival poet coconut error act';
+      const network = LiquidNetwork.testnet;
+      final descriptor = await Descriptor.newConfidential(
+        network: network,
+        mnemonic: mnemonic,
+      );
+      final wallet = await Wallet.init(
+        network: network,
+        dbpath: dbDirectory.path,
+        descriptor: descriptor,
+      );
+
+      final first = await wallet.addressWithBlindingSecret(index: 0);
+      final second = await wallet.addressWithBlindingSecret(index: 1);
+
+      expect(first.blindingSecret, matches(RegExp(r'^[0-9a-f]{64}$')));
+      expect(first.address.index, 0);
+      expect(first.address.blindingKey, isNotNull);
+      expect(second.address.index, 1);
+      expect(second.address.confidential, isNot(first.address.confidential));
+      expect(second.blindingSecret, isNot(first.blindingSecret));
+    });
+  });
+
   group('Wallet', () {
     test('Wallet Flow', () async {
       await LibLwk.init();
@@ -54,5 +96,7 @@ void main() {
       //     network: network, pset: pset, mnemonic: mnemonic);
       // print(signedPset);
     });
-  }, skip: 'live mainnet integration test: requires network + compiled lwk lib');
+  },
+      skip:
+          'live mainnet integration test: requires network + compiled lwk lib');
 }


### PR DESCRIPTION
## Summary

- expose a paired wallet address and per-address Liquid blinding secret
- derive the secret inside LWK with `lwk_common::derive_blinding_key`
- preserve the existing public `Address.blindingKey` contract
- regenerate Rust, Dart, iOS, and macOS FRB bindings

## Status

Draft replacement for reverted PR #89. Do not merge until the mobile stack completes certification and the owner explicitly authorizes it.

The branch reproduces the exact source tree previously reviewed in PR #89; it is based on the restored current `main`.

## Verification

- `cargo test --locked`: 2 passed, 3 ignored
- generated Dart binding test: 1 passed, 1 existing skipped
- secret is exactly 64 hex characters
- derived public key matches `Address.blindingKey`
- different address indexes produce different secrets

No SLIP77 derivation is added to Dart.